### PR TITLE
feat: add oauth link to github

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -61,7 +61,8 @@
         <nav>
             <ul>
                 <li><a href="/logros">🏅 Logros</a></li>
-                <li><a href="/login"> 👩‍💻 Iniciar sesión</a></li>
+                <li><a href="https://github.com/login/oauth/authorize?client_id=77a88aaa5e4cd67cff18"> 👩‍💻 Iniciar
+                        sesión</a></li>
             </ul>
     </header>
     <main>


### PR DESCRIPTION
Esto implementa un login "fake" que te lleva a la página OAuth de Github, te pide iniciar sesión a nuestra app (ya registrada) y te retorna a https://perfiles.osuc.dev/admin/?login=true (la URL de callback). Así podemos empezar a trabajar en `admin/` sin preocuparnos por implementar un botón falso de admin.