### PR TITLE
fix: use npm on ci

### DIFF
--- a/.github/workflows/frontend-node.yml
+++ b/.github/workflows/frontend-node.yml
@@ -1,4 +1,4 @@
-name: Frontend Node CI
+name: Frontend CI
 
 on: pull_request
 
@@ -10,8 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: yarn install
+        run: npm install
       - name: Run ESLint
-        run: yarn lint
-      - name: Run Tests
-        run: yarn test
+        run: npm run lint


### PR DESCRIPTION
El workflow que estamos está configurado con `yarn`, pero el repo usa `npm`. Adicionalmente incluía tests, pero no usamos tests en el front-end, por lo que todos los PRs estaban fallando.