### PR TITLE
fix: we don't do that here

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,5 @@
         "dbaeumer.vscode-eslint",
         "rvest.vs-code-prettier-eslint",
         "tonybaloney.vscode-pets",
-        "GitHub.copilot"
     ]
 }


### PR DESCRIPTION
Removed GitHub Copilot from the recommended extensions, as **we don't do that here**