### PR TITLE
refactor: improved js import from bottom-of-body to defer loading

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -47,6 +47,7 @@
     <link
         href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=League+Spartan:wght@400;700&display=swap"
         rel="stylesheet">
+    <script defer src="/assets/scripts/index.js"></script>
 
 </head>
 
@@ -108,7 +109,6 @@
                     alt="Flecha curvándose hacia si misma" title="ShareAlike"></a>
         </p>
     </footer>
-    <script src="/assets/scripts/index.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Cambio menor de la importación del js desde el fondo del body, a un defer en el head, ya que recientemente es más preferible.

[Explanation](https://flaviocopes.com/javascript-async-defer/)